### PR TITLE
feat: have the snap file located in `out/make` directory once created

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ electron-forge make --target="@davidwinter/electron-forge-maker-snap"
 Run with `DEBUG='snap-packager'` for debug output from `snapcraft`:
 
 ```
-DEBUG='snap-packager' electron-forge make --target="@davidwinter/electron-forge-maker-snap"
+DEBUG='forge-maker-snap:*' electron-forge make --target="@davidwinter/electron-forge-maker-snap"
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Then make your snap package:
 electron-forge make --target="@davidwinter/electron-forge-maker-snap"
 ```
 
+Once completed, the snap package will be located at: `out/make` with a filename like `{executable}-{version}.snap`, for example, `nimblenote-2.0.3.snap`
+
 Run with `DEBUG='snap-packager'` for debug output from `snapcraft`:
 
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const MakerBase = require('@electron-forge/maker-base').default;
 const SnapPackager = require('./snap-packager');
 const fse = require('fs-extra');
+const path = require('path');
 const {spawn} = require('child_process');
 
 module.exports = class MakerSnap extends MakerBase {
@@ -27,8 +28,18 @@ module.exports = class MakerSnap extends MakerBase {
 		});
 
 		pkg.createSnapcraftFiles();
-		pkg.createSnapPackage();
 
-		return [`${pkg.values.executableName}_${pkg.values.version}_amd64.snap`];
+		const snapFileLocation = await pkg.createSnapPackage();
+		const snapFilename = path.basename(snapFileLocation);
+
+		const finalSnapLocation = path.join(options.makeDir, snapFilename);
+
+		fse.renameSync(snapFileLocation, finalSnapLocation);
+
+		const snapcraftDirectory = path.dirname(snapFileLocation);
+
+		fse.rmdirSync(snapcraftDirectory, {recursive: true});
+
+		return [finalSnapLocation];
 	}
 };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const SnapPackager = require('./snap-packager');
 const fse = require('fs-extra');
 const path = require('path');
 const {spawn} = require('child_process');
-const debug = require('debug')('electron-forge-maker-snap:maker-snap');
+const debug = require('debug')('forge-maker-snap:maker-snap');
 
 module.exports = class MakerSnap extends MakerBase {
 	constructor(configFetcher, providedPlatforms) {

--- a/snap-packager.js
+++ b/snap-packager.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const ini = require('ini');
 const yaml = require('js-yaml');
-const debug = require('debug')('electron-forge-maker-snap:snap-packager');
+const debug = require('debug')('forge-maker-snap:snap-packager');
 
 const SnapValues = require('./snap-values');
 

--- a/snap-packager.js
+++ b/snap-packager.js
@@ -89,11 +89,18 @@ module.exports = class SnapCommand {
 	async createSnapPackage() {
 		let result = null;
 
+		const snapFile = `${this.values.executableName}-${this.values.version}.snap`;
+		const pathToSnapFile = path.join(this.options.makeOptions.makeDir, 'snapcraft', snapFile);
+
+		debug(`Snap to create: ${snapFile}`);
+
 		try {
 			result = await new Promise((resolve, reject) => {
-				const snapcraft = this.deps.spawn('snapcraft', [], {
+				const snapcraft = this.deps.spawn('snapcraft', ['snap', '--output', snapFile], {
 					cwd: path.join(this.options.makeOptions.makeDir, 'snapcraft')
 				});
+
+				debug('Snapcraft is now running...');
 
 				snapcraft.on('close', code => {
 					if (code === 0) {
@@ -113,11 +120,13 @@ module.exports = class SnapCommand {
 				});
 			});
 		} catch (error) {
-			throw new Error(error);
+			debug(`Snapcraft error: ${error.stderr}`);
+
+			throw new Error(error.stderr);
 		}
 
 		debug(`snapcraft finished with status code: ${result}`);
 
-		return result === 0;
+		return pathToSnapFile;
 	}
 };

--- a/snap-packager.test.js
+++ b/snap-packager.test.js
@@ -162,6 +162,6 @@ if (!process.env.FAST_TESTS) {
 		t.true(await pkg.createSnapPackage());
 
 		t.true(fse.existsSync(path.join(
-			makeOptions.makeDir, 'snapcraft', 'nimble-notes-v3_2.0.3_amd64.snap')));
+			makeOptions.makeDir, 'nimble-notes-v3-2.0.3.snap')));
 	});
 }

--- a/snap-packager.test.js
+++ b/snap-packager.test.js
@@ -162,7 +162,7 @@ if (!process.env.FAST_TESTS) {
 		const snapfilePath = await pkg.createSnapPackage();
 
 		t.is(snapfilePath, path.join(
-			makeOptions.makeDir, 'nimble-notes-v3-2.0.3.snap'));
+			makeOptions.makeDir, 'snapcraft', 'nimble-notes-v3-2.0.3.snap'));
 
 		t.true(fse.existsSync(snapfilePath));
 	});

--- a/snap-packager.test.js
+++ b/snap-packager.test.js
@@ -159,9 +159,11 @@ if (!process.env.FAST_TESTS) {
 
 		t.true(fse.existsSync(path.join(destDir, 'app')));
 
-		t.true(await pkg.createSnapPackage());
+		const snapfilePath = await pkg.createSnapPackage();
 
-		t.true(fse.existsSync(path.join(
-			makeOptions.makeDir, 'nimble-notes-v3-2.0.3.snap')));
+		t.is(snapfilePath, path.join(
+			makeOptions.makeDir, 'nimble-notes-v3-2.0.3.snap'));
+
+		t.true(fse.existsSync(snapfilePath));
 	});
 }


### PR DESCRIPTION
The `snap` file was located within `out/make/snapcraft` which was just a directory created to generate the actual `snap` file. It is custom for generated packages with `electron-forge` to end up in just `out/make`.