### PR TITLE
fix: ensure that the packaged executable is renamed to a snap friendly one

### DIFF
--- a/snap-packager.js
+++ b/snap-packager.js
@@ -87,6 +87,9 @@ module.exports = class SnapPackager {
 		this.deps.fse.copySync(this.options.makeOptions.dir, appFiles);
 		debug(`App files copied to: ${appFiles}`);
 
+		this.deps.fse.renameSync(path.join(appFiles, this.values.packagedExecutableName), path.join(appFiles, this.values.executableName));
+		debug(`Rename '${this.values.packagedExecutableName} to ${this.values.executableName} in: ${appFiles}`);
+
 		return true;
 	}
 

--- a/snap-packager.test.js
+++ b/snap-packager.test.js
@@ -23,7 +23,7 @@ const makeOptions = {
 		// Description = description
 	},
 	targetArch: 'x64',
-	dir: './test/artifacts/out/nimble-notes-v3-linux-x64', // '/Users/davidwinter/projects/nimblenote/out/nimblenote-linux-x64',
+	dir: './test/artifacts/out/Nimble Notes v3!-linux-x64', // '/Users/davidwinter/projects/nimblenote/out/nimblenote-linux-x64',
 	makeDir: './test/artifacts/make', // '/Users/davidwinter/projects/nimblenote/out/make',
 	targetPlatform: 'linux'
 };
@@ -63,6 +63,7 @@ test('packager setup without overrides', t => {
 	t.is(pkg.values.applicationName, 'Nimble Notes v3!');
 	t.is(pkg.values.version, '2.0.3');
 	t.is(pkg.values.executableName, 'nimble-notes-v3');
+	t.is(pkg.values.packagedExecutableName, 'Nimble Notes v3!');
 	t.is(pkg.values.icon, path.join(process.cwd(), 'test/fixtures/icon.png'));
 	t.is(pkg.values.summary, 'Simple note taking');
 	t.is(pkg.values.description, 'Simple note taking');
@@ -133,7 +134,7 @@ if (!process.env.FAST_TESTS) {
 		await packager({
 			dir: './test/fixtures/app',
 			out: './test/artifacts/out',
-			name: 'nimble-notes-v3',
+			name: 'Nimble Notes v3!',
 			platform: 'linux',
 			overwrite: true,
 			quiet: true

--- a/snap-values.js
+++ b/snap-values.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const LinuxApp = require('electron-packager/src/linux').App;
 
 class SnapValues {
 	constructor(options) {
@@ -20,6 +21,14 @@ class SnapValues {
 
 	get executableName() {
 		return this._sanatizeExecutableName(this.makerOptions.executableName || this.makeOptions.appName);
+	}
+
+	get packagedExecutableName() {
+		const linuxApp = new LinuxApp({
+			name: this.makeOptions.appName
+		});
+
+		return linuxApp.newElectronName;
 	}
 
 	get version() {

--- a/snap-values.test.js
+++ b/snap-values.test.js
@@ -67,6 +67,14 @@ test('executableName can be overriden with make options', t => {
 	t.is(values.executableName, 'nimblenote');
 });
 
+test('packagedExecutableName is calculated from electron-packager', t => {
+	const makerOptions = {};
+
+	const values = new SnapValues({makeOptions, makerOptions});
+
+	t.is(values.packagedExecutableName, 'Nimble Notes v3!');
+});
+
 test('version will be derived from package.json', t => {
 	const makerOptions = {};
 	const values = new SnapValues({makeOptions, makerOptions});


### PR DESCRIPTION
The executable name that electron-packager passes over to forge needs to be renamed to a snap
friendly one that works with the snapcraft.yaml file.